### PR TITLE
Add the possiblity to replace messages in the message queue

### DIFF
--- a/src/Editor.h
+++ b/src/Editor.h
@@ -17,6 +17,7 @@ class Editor: public Listener
 {
 public:
 	static const int maxChildren = 128;
+	static const int replacePreviousMessage = -1;
 
 	enum MessageClass
 	{
@@ -42,6 +43,7 @@ protected:
 	SDL_Rect mThisArea;
 	int mNumChildren;
 	bool mWantsFocus;
+	int mPopupMessageId;
 
 	void removeFocus();
 	void setModal(Editor *modal);
@@ -53,6 +55,9 @@ protected:
 
 	bool shouldRedrawBackground() const;
 	virtual void onAreaChanged(const SDL_Rect& area);
+
+	/* Actual rendering of the message */
+	virtual int showMessageInner(MessageClass messageClass, int messageId, const char* message);
 
 public:
 	Editor(EditorState& editorState, bool wantFocus = true);
@@ -91,9 +96,10 @@ public:
 	/**
 	 * Status popup
 	 */
-	virtual void showMessage(MessageClass messageClass, const char* message);
-	void showMessageV(MessageClass messageClass, const char* message, ...) __attribute__((format(printf, 3, 4)));
-
+	int showMessage(MessageClass messageClass, int messageId, const char* message);
+	int showMessage(MessageClass messageClass, const char* message);
+	int showMessageV(MessageClass messageClass, const char* message, ...) __attribute__((format(printf, 3, 4)));
+	int showMessageV(MessageClass messageClass, int messageId, const char* message, ...) __attribute__((format(printf, 4, 5)));
 
 	void draw(Renderer& renderer, const SDL_Rect& area);
 	virtual void onUpdate(int ms);

--- a/src/MainEditor.cpp
+++ b/src/MainEditor.cpp
@@ -1,4 +1,3 @@
-#include "Debug.h"
 #include "MainEditor.h"
 #include "IPlayer.h"
 #include "PatternEditor.h"
@@ -846,7 +845,7 @@ bool MainEditor::exportSong()
 #ifndef __EMSCRIPTEN__
 	if (SDL_SetClipboardText(section->getBase64()))
 	{
-		debug("SDL_GetError: %s", SDL_GetError());
+		showMessageV(MessageClass::MessageError, "SDL_GetError: %s", SDL_GetError());
 	}
 
 #else
@@ -908,9 +907,9 @@ void MainEditor::newSong()
 }
 
 
-void MainEditor::showMessage(MessageClass messageClass, const char* message)
+int MainEditor::showMessageInner(MessageClass messageClass, int messageId, const char* message)
 {
-	mMessageManager->pushMessage(messageClass, message);
+	return mMessageManager->pushMessage(messageClass, message, messageId);
 }
 
 

--- a/src/MainEditor.h
+++ b/src/MainEditor.h
@@ -68,8 +68,8 @@ public:
 	virtual bool onEvent(SDL_Event& event);
 	virtual void onDraw(Renderer& renderer, const SDL_Rect& area);
 	virtual void onFileSelectorEvent(const Editor& fileSelector, bool accept);
-	virtual void showMessage(MessageClass messageClass, const char* message);
 	virtual void showTooltip(const SDL_Rect& area, const char* message);
+	virtual int showMessageInner(MessageClass messageClass, int messageId, const char* message);
 
 	void cycleFocus();
 	void syncPlayerState();

--- a/src/MessageManager.h
+++ b/src/MessageManager.h
@@ -1,41 +1,48 @@
 #pragma once
 
-#include <queue>
+#include <list>
 #include <string>
 #include "Editor.h"
 
-class MessageManager 
+class MessageManager
 {
 public:
 	static const int MessageVisibleMs = 2000;
 	static const int MessageAnimationMs = 100;
 
-	struct Message 
+	struct Message
 	{
-		// Remaining milliseconds the message should still be displayed 
+		int id;
+		// Remaining milliseconds the message should still be displayed
 		// value (will decrease)
 		int delay;
 		Editor::MessageClass messageClass;
 		std::string text;
-		
-		Message(Editor::MessageClass messageClass, const std::string& message);
-		
+
+		Message(int id, Editor::MessageClass messageClass, const std::string& message);
+		void resetDelay();
+
 		float getVisibility() const;
 	};
-	
+
 private:
 	bool mWasVisible;
-	std::queue<Message> mMessageQueue;
-	
+	std::list<Message> mMessageQueue;
+	int mMessageIDCounter;
+
 public:
 	MessageManager();
 	void update(int ms);
-	void pushMessage(Editor::MessageClass messageClass, const std::string& message);
-	
+
+	/* Push a new message in the queue or replace the message with the matching ID
+	 * Returns the message ID for the new message
+	 */
+	int pushMessage(Editor::MessageClass messageClass, const std::string& message, int messageId = 0);
+
 	/* Get topmost queued message
 	 */
 	const Message* getVisibleMessage() const;
-	
+
 	/* Returns true if there was a message in the queue since last update()
 	 */
 	bool getWasMessageVisibleLastFrame() const;

--- a/src/SequenceRowEditor.cpp
+++ b/src/SequenceRowEditor.cpp
@@ -306,7 +306,7 @@ void SequenceRowEditor::duplicateRow()
 
 	mTrackEditorState.currentRow.notify();
 
-	showMessage(MessageInfo, "Duplicated sequence row");
+	showMessage(MessageInfo, replacePreviousMessage, "Duplicated sequence row");
 }
 
 


### PR DESCRIPTION
It is now possible to replace messages so that repeating events (e.g. duplicating pattern rows) will not push tons of messages in the queue.

The Editor base class has been updated so that showMessage() returns an ID that can be used to replace messages later. In addition, a special predefined ID "replacePreviousMessage" can be used to easily replace the per Editor message.